### PR TITLE
request flow and threads functionality

### DIFF
--- a/dune_ledger_bot/Cargo.lock
+++ b/dune_ledger_bot/Cargo.lock
@@ -340,6 +340,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,10 +411,12 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 name = "dune_ledger_bot"
 version = "0.1.0"
 dependencies = [
+ "dashmap 6.1.0",
  "dotenvy",
  "google-sheets4",
  "hyper 0.14.32",
  "hyper-util",
+ "once_cell",
  "poise",
  "regex",
  "serde",
@@ -1182,7 +1198,7 @@ checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap",
+ "dashmap 5.5.3",
  "skeptic",
  "smallvec",
  "tagptr",
@@ -1900,7 +1916,7 @@ dependencies = [
  "bytes",
  "chrono",
  "command_attr",
- "dashmap",
+ "dashmap 5.5.3",
  "flate2",
  "futures",
  "fxhash",
@@ -2323,7 +2339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da66c62c5b7017a2787e77373c03e6a5aafde77a73bff1ff96e91cd2e128179"
 dependencies = [
  "chrono",
- "dashmap",
+ "dashmap 5.5.3",
  "hashbrown 0.14.5",
  "mini-moka",
  "parking_lot",

--- a/dune_ledger_bot/Cargo.toml
+++ b/dune_ledger_bot/Cargo.toml
@@ -30,5 +30,7 @@ google-sheets4 = "6.0.0"
 hyper = "0.14"
 yup-oauth2 = "8"
 hyper-util = "0.1.15"
+once_cell = "1.21.3"
+dashmap = "6.1.0"
 
 

--- a/dune_ledger_bot/src/commands/request.rs
+++ b/dune_ledger_bot/src/commands/request.rs
@@ -1,8 +1,26 @@
 use crate::{BotError, Context};
+use dashmap::DashMap;
+use once_cell::sync::Lazy;
+use poise::serenity_prelude::{
+    ChannelId, CreateEmbed, CreateMessage, CreateThread, Message, MessageId, UserId,
+};
 use regex::Regex;
-// use regex::Regex;
+use std::collections::HashMap;
 
-#[poise::command(slash_command, subcommands("start", "bulk_add"), subcommand_required)]
+// for storing a request in-progress, and for the bot to manipulate
+struct InProgressRequest {
+    product: String,
+    resources: Vec<(u64, String)>,
+    sheet_row_ids: Vec<String>,
+    message_id: MessageId,
+}
+static IN_FLIGHT: Lazy<DashMap<UserId, InProgressRequest>> = Lazy::new(Default::default);
+
+#[poise::command(
+    slash_command,
+    subcommands("start", "bulk_add", "finish"),
+    subcommand_required
+)]
 pub async fn request(_: Context<'_>) -> Result<(), BotError> {
     Ok(())
 }
@@ -12,29 +30,73 @@ pub async fn start(
     ctx: Context<'_>,
     #[description = "Title for the request"] product: String,
 ) -> Result<(), BotError> {
-    ctx.reply(format!("Request received for: {}.", product))
+    let user = ctx.author().id;
+
+    // Prevent overlapping requests
+    if IN_FLIGHT.contains_key(&user) {
+        ctx.say("❌ You already have a pending request. Please finish it with `/request finish` before starting a new one.")
+            .await?;
+        return Ok(());
+    }
+
+    let confirmation_builder = CreateMessage::new().content(format!(
+        "✅ Request started for **{}**.\n\
+             Now add resources with `/request bulk_add`, then finalize with `/request finish`.",
+        product
+    ));
+
+    // Send confirmation and capture the message ID
+    let confirmation: Message = ctx
+        .channel_id()
+        .send_message(&ctx.http(), confirmation_builder)
         .await?;
+
+    // Store in-flight state
+    IN_FLIGHT.insert(
+        user,
+        InProgressRequest {
+            product: product.clone(),
+            resources: Vec::new(),
+            sheet_row_ids: Vec::new(),
+            message_id: confirmation.id,
+        },
+    );
+
     Ok(())
 }
 
-async fn sanitize(ctx: Context<'_>, input: &str) -> Result<(), BotError> {
-    let sanitized_list: &str = &input.replace(',', "").replace(" x ", " ").replace("-", "");
+// *Expects raw resource list pasted from crafting calc i.e. https://dune.geno.gg/calculator/
+async fn parse_resources(ctx: &Context<'_>, input: &str) -> Result<String, BotError> {
+    // Sanitize input...
+    let sanitized_list = input
+        .replace(',', "")
+        .replace(" x ", " ")
+        .replace("-", "")
+        .replace("•", "")
+        .replace(":", "");
     let re = Regex::new(r"(?<amount>[0-9]+)(?<name>\s+([A-Za-z]+\s*)+)").unwrap();
-
+    // ...and parse input into amount:resource pairs
     let mut results: Vec<(u64, String)> = Vec::new();
-    for (_, [amount, resource, _]) in re.captures_iter(sanitized_list).map(|c| c.extract()) {
+    for (_, [amount, resource, _]) in re.captures_iter(&sanitized_list).map(|c| c.extract()) {
         results.push((amount.parse::<u64>()?, resource.trim().to_string()));
     }
+
+    // Pull out the in‐flight request, update its resources, and re‐insert
+    let user: UserId = ctx.author().id;
+    let mut entry = IN_FLIGHT
+        .remove(&user)
+        .ok_or("❌ You have no active request. Start with `/request start`.")?
+        .1;
+    entry.resources = results.clone();
+    IN_FLIGHT.insert(user, entry);
+
+    // Build human‐readable summary of resource list
     let lines: Vec<String> = results
         .iter()
         .map(|(amount, name)| format!("• {} x {},", amount, name))
         .collect();
-
     let body = lines.join("\n");
-    let body = body.trim_end_matches(",");
-    ctx.say(format!("```✅ Parsed resources:\n{}```", body))
-        .await?;
-    Ok(())
+    Ok(body.trim_end_matches(",").to_string())
 }
 
 #[poise::command(slash_command)]
@@ -42,6 +104,79 @@ pub async fn bulk_add(
     ctx: Context<'_>,
     #[description = "Paste the raw resource list here"] raw_resource_list: String,
 ) -> Result<(), BotError> {
-    sanitize(ctx, &raw_resource_list).await?;
+    // Show the user a preview using your existing formatter
+    let preview: String = parse_resources(&ctx, &raw_resource_list).await?;
+    ctx.say(format!(
+        "✅ Resources recorded.```{}```Now finalize your request with `/request finish`.",
+        preview
+    ))
+    .await?;
+
+    Ok(())
+}
+
+async fn load_inventory_from_sheets() -> Result<HashMap<String, u64>, BotError> {
+    // TODO: replace with real Sheets lookup
+    let inventory = HashMap::new();
+    Ok(inventory)
+}
+
+#[poise::command(slash_command)]
+pub async fn finish(ctx: Context<'_>) -> Result<(), BotError> {
+    let user = ctx.author().id;
+
+    // Post in a pre-defined channel specific for request threads
+    let target_channel_id: ChannelId = std::env::var("REQUESTS_CHANNEL_ID")?.parse::<u64>()?.into();
+
+    // Access the stored request data
+    let entry = IN_FLIGHT
+        .remove(&user)
+        .ok_or("You have no active request. Start one with `/request start`.")?
+        .1;
+
+    // Compute required diff vs. sheet inventory for final request posting
+    let inventory = load_inventory_from_sheets().await?;
+    let needed: Vec<(u64, String)> = entry
+        .resources
+        .into_iter()
+        .filter_map(|(req_amt, name)| {
+            let stock = *inventory.get(&name).unwrap_or(&0);
+            req_amt
+                .checked_sub(stock)
+                .filter(|&n| n > 0)
+                .map(|n| (n, name))
+        })
+        .collect();
+
+    // Build the embed
+    let rem_text = needed
+        .iter()
+        .map(|(amt, nm)| format!("• {} x {}", amt, nm))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let embed = CreateEmbed::new()
+        .title(format!("🔷 CRAFTING REQUEST: {}", entry.product))
+        .field("✅ Completed:", "Nothing yet…", false)
+        .field("🛠️ Remaining Materials:", rem_text, false);
+
+    let msg_builder = CreateMessage::new().embed(embed.clone());
+    let post: Message = target_channel_id
+        .send_message(&ctx.http(), msg_builder)
+        .await?;
+
+    // Build and create the public thread from that message
+    let thread_builder = CreateThread::new(format!("{} - submissions", entry.product));
+    let thread = target_channel_id
+        .create_thread_from_message(&ctx.http(), post.id, thread_builder)
+        .await?;
+
+    // Send your info message in the thread
+    let info_builder = CreateMessage::new().content(
+        "🛠 Please bring the materials to the Guild base for crafting. \n\n\
+         Post below with what you've donated/contributed so we know the progress.\n\n\
+         Let us know if you need help locating any of the resources on the list.",
+    );
+    let _ = thread.send_message(&ctx.http(), info_builder).await?;
+
     Ok(())
 }

--- a/dune_ledger_bot/src/commands/submit.rs
+++ b/dune_ledger_bot/src/commands/submit.rs
@@ -1,11 +1,10 @@
 use crate::BotError;
 use crate::Context;
 
-use std::env;
 use dotenvy::dotenv;
 use google_sheets4 as sheets4;
-use sheets4::{api::ValueRange, Sheets, hyper_rustls, yup_oauth2};
-
+use sheets4::{Sheets, api::ValueRange, hyper_rustls, yup_oauth2};
+use std::env;
 
 #[poise::command(slash_command)]
 pub async fn submit(
@@ -15,26 +14,25 @@ pub async fn submit(
 ) -> Result<(), BotError> {
     dotenv().ok();
 
-    let service_account_key = yup_oauth2::read_service_account_key("secrets/voltaic-bridge-465115-j2-f15defee98d4.json")
-        .await
-        .expect("Can't read credential, an error occurred");
+    let service_account_key =
+        yup_oauth2::read_service_account_key("secrets/voltaic-bridge-465115-j2-f15defee98d4.json")
+            .await
+            .expect("Can't read credential, an error occurred");
 
     let authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(service_account_key)
         .build()
         .await
         .expect("failed to create authenticator");
-    
-    let client = hyper_util::client::legacy::Client::builder(
-        hyper_util::rt::TokioExecutor::new()
-    )
-    .build(
-        hyper_rustls::HttpsConnectorBuilder::new()
-            .with_native_roots()
-            .unwrap()
-            .https_or_http()
-            .enable_http1()
-            .build()
-    );
+
+    let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+        .build(
+            hyper_rustls::HttpsConnectorBuilder::new()
+                .with_native_roots()
+                .unwrap()
+                .https_or_http()
+                .enable_http1()
+                .build(),
+        );
 
     let hub = Sheets::new(client, authenticator);
 
@@ -42,22 +40,32 @@ pub async fn submit(
     // let request_spreadsheet_id = env::var("SPREADSHEET_ID_REQUEST");
     let range = "Sheet1!A:B";
 
-    let ledger_values = hub.spreadsheets().values_get(&ledger_spreadsheet_id, range)
-        .doit().await?.1.values.unwrap_or_default();
+    let ledger_values = hub
+        .spreadsheets()
+        .values_get(&ledger_spreadsheet_id, range)
+        .doit()
+        .await?
+        .1
+        .values
+        .unwrap_or_default();
 
     let mut found_in_ledger = false;
     let mut updated_ledger_values = vec![];
 
     for row in ledger_values {
         if let Some(name_val) = row.get(0) {
-            if let Some(name) = name_val.as_str(){
+            if let Some(name) = name_val.as_str() {
                 if name.to_lowercase() == resource.to_lowercase() {
-                    let current: i32 = row.get(1)
+                    let current: i32 = row
+                        .get(1)
                         .and_then(|v| v.as_str())
                         .and_then(|s| s.parse::<i32>().ok())
                         .unwrap_or(0);
                     let new_value = current + amount;
-                    updated_ledger_values.push(vec![resource.clone().into(), new_value.to_string().to_lowercase().into()]);
+                    updated_ledger_values.push(vec![
+                        resource.clone().into(),
+                        new_value.to_string().to_lowercase().into(),
+                    ]);
                     found_in_ledger = true;
                 } else {
                     updated_ledger_values.push(row.clone());
@@ -67,22 +75,29 @@ pub async fn submit(
     }
 
     if !found_in_ledger {
-        updated_ledger_values.push(vec![resource.clone().into(), amount.to_string().to_lowercase().into()]);
+        updated_ledger_values.push(vec![
+            resource.clone().into(),
+            amount.to_string().to_lowercase().into(),
+        ]);
     }
 
     hub.spreadsheets()
-    .values_update(
-        ValueRange {
-            values: Some(updated_ledger_values),
-            ..Default::default()
-        },
-        &ledger_spreadsheet_id,
-        range
-    )
-    .value_input_option("RAW")
-    .doit()
-    .await?;
+        .values_update(
+            ValueRange {
+                values: Some(updated_ledger_values),
+                ..Default::default()
+            },
+            &ledger_spreadsheet_id,
+            range,
+        )
+        .value_input_option("RAW")
+        .doit()
+        .await?;
 
-    ctx.say(format!("✅ Submitted {} of {} to the sheet!", amount, resource)).await?;
+    ctx.say(format!(
+        "✅ Submitted {} of {} to the sheet!",
+        amount, resource
+    ))
+    .await?;
     Ok(())
 }

--- a/dune_ledger_bot/src/main.rs
+++ b/dune_ledger_bot/src/main.rs
@@ -2,23 +2,21 @@ mod commands;
 use commands::request::request;
 use commands::submit::submit;
 
-use std::env;
 use dotenvy::dotenv;
 use poise::serenity_prelude as serenity;
+use std::env;
 
 struct Data {}
 
 type BotError = Box<dyn std::error::Error + Send + Sync>;
 type Context<'a> = poise::Context<'a, Data, BotError>;
 
-
 #[tokio::main]
 async fn main() -> Result<(), BotError> {
     dotenv().ok();
 
     // ─── Bot startup ─────────────────────────────────────────
-    let token = env::var("DISCORD_TOKEN")
-        .expect("Expected DISCORD_TOKEN in env");
+    let token = env::var("DISCORD_TOKEN").expect("Expected DISCORD_TOKEN in env");
     let intents = serenity::GatewayIntents::non_privileged();
 
     let options = poise::FrameworkOptions {
@@ -35,7 +33,7 @@ async fn main() -> Result<(), BotError> {
                 let guild = serenity::model::id::GuildId::new(guild_id);
                 poise::builtins::register_in_guild(http, &framework.options().commands, guild)
                     .await?;
-                Ok(Data { })
+                Ok(Data {})
             })
         })
         .build();


### PR DESCRIPTION
Add /request flow and thread creation functionality via subcommands:
  - /request start: begins a new crafting request and stores global state
  - /request bulk_add: parses and attaches a resource list to the active request
  - /request finish: posts an embed with remaining materials, creates a public thread, and sends a contribution message

Added functionality:
- Prevents duplicate /request start sessions per user until previous request finished
- Uses DashMap (IN_FLIGHT) for tracking in-progress requests
- Posts final output to a configured target channel
- Adds user feedback confirmations in both /start and /bulk_add steps

TODO:
- Read the inventory sheet & calculate diff to see final request numbers