### PR TITLE
Taqft dev

### DIFF
--- a/dune_ledger_bot/.env.example
+++ b/dune_ledger_bot/.env.example
@@ -1,0 +1,16 @@
+# Path to your Google service account JSON
+GOOGLE_SVC_ACCOUNT_KEY=./creds/service-account.json
+
+# Your Discord bot token (keep this secret!)
+DISCORD_TOKEN=YOUR_DISCORD_BOT_TOKEN_HERE
+
+# The ID of your development/testing guild
+GUILD_ID=123456789012345678
+
+# Google Sheets IDs for the different ledgers
+SPREADSHEET_ID_LEDGER=1A2B3C4D5E6F7G8H9I0J
+SPREADSHEET_ID_REQUEST=1Z2Y3X4W5V6U7T8S9R0Q
+SPREADSHEET_ID_INVENTORY=1K2L3M4N5O6P7Q8R9S0T
+
+# The channel in which “/request finish” posts its threads
+REQUESTS_CHANNEL_ID=987654321098765432

--- a/dune_ledger_bot/src/commands/request.rs
+++ b/dune_ledger_bot/src/commands/request.rs
@@ -329,13 +329,12 @@ pub async fn finish(ctx: Context<'_>) -> Result<(), BotError> {
         .title(format!("🔷 CRAFTING REQUEST: {}", entry.product))
         .field("🛠️ Request Materials:", request_text, false);
 
-    let msg_builder = CreateMessage::new()
-        .embed(embed.clone());
+    let msg_builder = CreateMessage::new().embed(embed.clone());
 
     let post: Message = target_channel_id
         .send_message(&ctx.http(), msg_builder)
         .await?;
-    
+
     let thread = target_channel_id
         .create_thread_from_message(&ctx.http(), post.id, thread_builder)
         .await?;
@@ -348,7 +347,7 @@ pub async fn finish(ctx: Context<'_>) -> Result<(), BotError> {
             name.clone().into(),
             req_amt.to_string().into(),
             "in_progress".into(),
-            thread.id.to_string().into()
+            thread.id.to_string().into(),
         ]);
     }
 
@@ -369,7 +368,6 @@ pub async fn finish(ctx: Context<'_>) -> Result<(), BotError> {
         .doit()
         .await?;
 
-    
     // Send static welcome message in the thread
     // TODO: Allow for adjustments to welcome message or request notes
     let info_builder = CreateMessage::new().content(
@@ -378,13 +376,14 @@ pub async fn finish(ctx: Context<'_>) -> Result<(), BotError> {
         Let us know if you need help locating any of the resources on the list.",
     );
     let _ = thread.send_message(&ctx.http(), info_builder).await?;
-    
+
     let new_thread_message = CreateMessage::new()
         .button(
             CreateButton::new(format!("request_update:{request_id}"))
                 .label("Update")
                 .style(ButtonStyle::Primary),
-        ).button(
+        )
+        .button(
             CreateButton::new(format!("request_complete:{request_id}"))
                 .label("Complete")
                 .style(ButtonStyle::Success),
@@ -393,5 +392,3 @@ pub async fn finish(ctx: Context<'_>) -> Result<(), BotError> {
     let _ = thread.send_message(&ctx.http(), new_thread_message).await?;
     Ok(())
 }
-
-

--- a/dune_ledger_bot/src/commands/submit.rs
+++ b/dune_ledger_bot/src/commands/submit.rs
@@ -158,7 +158,7 @@ pub async fn submit(
         .await?;
         return Ok(()); // Exit early
     }
-    
+
     for row in ledger_values {
         if let Some(name_val) = row.get(0) {
             if let Some(name) = name_val.as_str() {
@@ -184,14 +184,13 @@ pub async fn submit(
             }
         }
     }
-    
+
     if !found_in_ledger {
         updated_ledger_values.push(vec![
             resource.clone().to_string().to_lowercase().into(),
             amount.into(),
         ]);
     }
-
 
     hub.spreadsheets()
         .values_update(

--- a/dune_ledger_bot/src/commands/submit.rs
+++ b/dune_ledger_bot/src/commands/submit.rs
@@ -87,7 +87,7 @@ const ALL_RESOURCES: &[&str] = &[
     "TriForged Hydraulic Piston",
 ];
 
-/// Autocomplete handler for the `resource: String` argument.
+// Ensure users only pick from a predetermined set of resources
 async fn resource_autocomplete<'a>(_ctx: Context<'a>, partial: &str) -> Vec<AutocompleteChoice> {
     ALL_RESOURCES
         .iter()
@@ -100,8 +100,9 @@ async fn resource_autocomplete<'a>(_ctx: Context<'a>, partial: &str) -> Vec<Auto
 #[poise::command(slash_command)]
 pub async fn submit(
     ctx: Context<'_>,
-    // #[description = "Resource to submit"]
-    #[autocomplete = "resource_autocomplete"] resource: String,
+    #[description = "Resource to submit"]
+    #[autocomplete = "resource_autocomplete"]
+    resource: String,
     #[description = "Amount to submit"] amount: i32,
 ) -> Result<(), BotError> {
     dotenv().ok();
@@ -129,7 +130,6 @@ pub async fn submit(
     let hub = Sheets::new(client, authenticator);
 
     let inventory_spreadsheet_id = var("SPREADSHEET_ID_INVENTORY")?;
-    // let request_spreadsheet_id = var("SPREADSHEET_ID_REQUEST");
     let range = "Sheet1!A:B";
 
     let ledger_values = hub
@@ -156,7 +156,7 @@ pub async fn submit(
             resource
         ))
         .await?;
-        return Ok(()); // Exit early
+        return Ok(());
     }
 
     for row in ledger_values {
@@ -224,7 +224,7 @@ pub async fn submit(
 
     let request_spreadsheet_id = var("SPREADSHEET_ID_REQUEST")?;
     let request_range = "Sheet1!A:D";
-    let mut inventory = load_inventory_from_sheets().await?; // refresh after update
+    let mut inventory = load_inventory_from_sheets().await?;
     let request_result = hub
         .spreadsheets()
         .values_get(&request_spreadsheet_id, request_range)

--- a/dune_ledger_bot/src/main.rs
+++ b/dune_ledger_bot/src/main.rs
@@ -1,15 +1,14 @@
 mod commands;
 mod utils;
 
-use utils::sheets::{load_inventory_from_sheets, load_request_from_sheets, complete_request};
+use utils::sheets::{complete_request, load_inventory_from_sheets, load_request_from_sheets};
 
 use commands::request::request;
 use commands::submit::submit;
 use dotenvy::dotenv;
 use poise::builtins::register_in_guild;
 use poise::serenity_prelude as serenity;
-// use serenity::builder::{CreateInteractionResponse, CreateInteractionResponseData};
-use serenity::{CreateMessage, CreateEmbed, GuildId};
+use serenity::{CreateEmbed, CreateMessage, GuildId};
 use std::env::var;
 
 type BotError = Box<dyn std::error::Error + Send + Sync>;
@@ -38,7 +37,7 @@ async fn main() -> Result<(), BotError> {
                 let http = &ctx.http;
                 let guild_id: u64 = var("GUILD_ID")?.parse()?;
                 let guild = GuildId::new(guild_id);
-                // *For de-registering leftover global commands
+                // *For de-registering leftover global commands:
                 // Command::set_global_commands(&ctx.http, Vec::new()).await?;
                 register_in_guild(http, &framework.options().commands, guild).await?;
                 Ok(Data {})
@@ -62,21 +61,20 @@ async fn event_handler(
 ) -> Result<(), BotError> {
     match event {
         // Login event demo
-        serenity::FullEvent::Ready { data_about_bot, .. } => {
-            println!("Logged in as {}", data_about_bot.user.name);
-        }
+        // serenity::FullEvent::Ready { data_about_bot, .. } => {
+        //     println!("Logged in as {}", data_about_bot.user.name);
+        // }
 
-        // **This** is where you catch *all* other interactions,
-        // including button clicks:
+        // *This is where you catch *all* other interactions,
+        // *including button clicks:
         serenity::FullEvent::InteractionCreate { interaction } => {
             if let serenity::Interaction::Component(comp) = interaction.clone() {
-                // dbg!("Comp:", &comp);
                 if comp.data.custom_id.starts_with("request_update") {
                     // ! THIS PREVENTS THE TIMEOUT!!!!
                     comp.defer(&ctx.http).await?;
 
-                    let request_id = comp.data.custom_id["request_update:".len()..].to_string(); 
-                    println!("Request id => {}", request_id);
+                    let request_id = comp.data.custom_id["request_update:".len()..].to_string();
+                    // println!("Request id => {}", request_id);
 
                     let inventory = load_inventory_from_sheets().await?;
                     let result = load_request_from_sheets(&request_id).await;
@@ -91,7 +89,11 @@ async fn event_handler(
                         if stock_amt >= *needed_amt {
                             completed.push(format!("• {} x {}", needed_amt, normalized_name));
                         } else {
-                            remaining.push(format!("• {} x {}", needed_amt - stock_amt, normalized_name));
+                            remaining.push(format!(
+                                "• {} x {}",
+                                needed_amt - stock_amt,
+                                normalized_name
+                            ));
                         }
                     }
 
@@ -120,7 +122,7 @@ async fn event_handler(
 
                     let response = thread_id.send_message(&ctx.http, msg).await;
                     match response {
-                        Ok(_) => println!("✅ Message sent to thread."),
+                        Ok(_) => (),
                         Err(e) => {
                             println!("❌ Error sending to thread: {:?}", e);
                             use std::io::Write;

--- a/dune_ledger_bot/src/main.rs
+++ b/dune_ledger_bot/src/main.rs
@@ -37,6 +37,7 @@ async fn main() -> Result<(), BotError> {
                 let http = &ctx.http;
                 let guild_id: u64 = var("GUILD_ID")?.parse()?;
                 let guild = GuildId::new(guild_id);
+                // TODO: Remove duplicate slash functions throwing errors
                 // *For de-registering leftover global commands:
                 // Command::set_global_commands(&ctx.http, Vec::new()).await?;
                 register_in_guild(http, &framework.options().commands, guild).await?;
@@ -74,7 +75,6 @@ async fn event_handler(
                     comp.defer(&ctx.http).await?;
 
                     let request_id = comp.data.custom_id["request_update:".len()..].to_string();
-                    // println!("Request id => {}", request_id);
 
                     let inventory = load_inventory_from_sheets().await?;
                     let result = load_request_from_sheets(&request_id).await;
@@ -100,7 +100,7 @@ async fn event_handler(
                     let embed = CreateEmbed::new()
                         .title(format!("🔷 CRAFTING REQUEST: {}", product_name))
                         .field(
-                            "✅ Completed:",
+                            "✅ In Stock:",
                             if completed.is_empty() {
                                 "Nothing yet...".into()
                             } else {

--- a/dune_ledger_bot/src/utils/sheets.rs
+++ b/dune_ledger_bot/src/utils/sheets.rs
@@ -96,8 +96,6 @@ pub async fn load_request_from_sheets(
             continue;
         }
 
-        // println!("✅ Matched row: {:?}", row);
-
         if product_name.is_empty() {
             product_name = row[1].to_string().clone();
         }
@@ -223,7 +221,7 @@ pub async fn complete_request(
 
     for mut row in sheet_data {
         if row.len() >= 5 && row[0] == request_id {
-            row[4] = Value::String("completed".to_string()); // status column
+            row[4] = Value::String("completed".to_string()); // `status` column
         }
         updated_rows.push(row);
     }

--- a/dune_ledger_bot/src/utils/sheets.rs
+++ b/dune_ledger_bot/src/utils/sheets.rs
@@ -1,11 +1,10 @@
 use crate::BotError;
 use dotenvy::dotenv;
 use google_sheets4 as sheets4;
+use poise::serenity_prelude as serenity;
+use serde_json::Value;
+use serenity::{ChannelId, ComponentInteraction, CreateEmbed, CreateMessage, EditThread};
 use sheets4::{Sheets, api::ValueRange, hyper_rustls, yup_oauth2};
-use serde_json::Value;use poise::serenity_prelude as serenity;
-use serenity::{
-    CreateMessage, ComponentInteraction, CreateEmbed, ChannelId
-};
 use std::{collections::HashMap, env::var};
 const SERVICE_ACCOUNT_PATH: &str = "secrets/voltaic-bridge-465115-j2-f15defee98d4.json";
 
@@ -57,7 +56,7 @@ pub async fn load_inventory_from_sheets() -> Result<HashMap<String, u64>, BotErr
 }
 
 pub async fn load_request_from_sheets(
-    request_id: &str
+    request_id: &str,
 ) -> Result<(String, HashMap<String, u64>, ChannelId), BotError> {
     dotenvy::dotenv().ok();
     let service_account_key = yup_oauth2::read_service_account_key(SERVICE_ACCOUNT_PATH)
@@ -97,7 +96,7 @@ pub async fn load_request_from_sheets(
             continue;
         }
 
-        println!("✅ Matched row: {:?}", row);
+        // println!("✅ Matched row: {:?}", row);
 
         if product_name.is_empty() {
             product_name = row[1].to_string().clone();
@@ -108,7 +107,6 @@ pub async fn load_request_from_sheets(
                 let cleaned = raw.to_string().replace(|c: char| !c.is_numeric(), "");
                 if let Ok(id_num) = cleaned.parse::<u64>() {
                     thread_id = Some(ChannelId::from(id_num));
-                    println!("✅ Parsed thread ID: {}", id_num);
                 } else {
                     println!("❌ Failed to parse thread ID: {:?}", raw);
                 }
@@ -128,7 +126,6 @@ pub async fn load_request_from_sheets(
     }
 
     let thread_id = thread_id.ok_or("No thread ID found for request")?;
-    dbg!(&product_name, &thread_id);
     Ok((product_name, resource_map, thread_id))
 }
 
@@ -142,7 +139,7 @@ pub fn normalize_resource_key(s: &str) -> String {
 
 pub async fn complete_request(
     ctx: &serenity::Context,
-    comp: &ComponentInteraction, 
+    comp: &ComponentInteraction,
     request_id: &str,
 ) -> Result<(), BotError> {
     dotenvy::dotenv().ok();
@@ -172,14 +169,18 @@ pub async fn complete_request(
     let mut inventory = load_inventory_from_sheets().await?;
     let (product_name, request_resources, thread_id) = load_request_from_sheets(request_id).await?;
 
-
-    let all_satisfied = request_resources.iter().all(|(name, amt)| {
-        inventory.get(name).copied().unwrap_or(0) >= *amt
-    });
+    let all_satisfied = request_resources
+        .iter()
+        .all(|(name, amt)| inventory.get(name).copied().unwrap_or(0) >= *amt);
 
     if !all_satisfied {
-        comp.channel_id.send_message(&ctx.http, serenity::builder::CreateMessage::new()
-            .content("❌ Not enough resources in inventory to complete this request.")).await?;
+        comp.channel_id
+            .send_message(
+                &ctx.http,
+                serenity::builder::CreateMessage::new()
+                    .content("❌ Not enough resources in inventory to complete this request."),
+            )
+            .await?;
         return Ok(());
     }
 
@@ -190,22 +191,33 @@ pub async fn complete_request(
         }
     }
 
-    let new_inventory_values: Vec<Vec<Value>> = inventory.into_iter()
-    .map(|(name, amt)| vec![Value::String(name), Value::String(amt.to_string())])
-    .collect();
+    let new_inventory_values: Vec<Vec<Value>> = inventory
+        .into_iter()
+        .map(|(name, amt)| vec![Value::String(name), Value::String(amt.to_string())])
+        .collect();
 
     hub.spreadsheets()
-        .values_update(ValueRange {
-            range: Some(ledger_range.to_string()),
-            values: Some(new_inventory_values),
-            ..Default::default()
-        }, &ledger_sheet_id, ledger_range)
+        .values_update(
+            ValueRange {
+                range: Some(ledger_range.to_string()),
+                values: Some(new_inventory_values),
+                ..Default::default()
+            },
+            &ledger_sheet_id,
+            ledger_range,
+        )
         .value_input_option("RAW")
         .doit()
         .await?;
 
-    let sheet_data = hub.spreadsheets().values_get(&request_sheet_id, request_range)
-        .doit().await?.1.values.unwrap_or_default();
+    let sheet_data = hub
+        .spreadsheets()
+        .values_get(&request_sheet_id, request_range)
+        .doit()
+        .await?
+        .1
+        .values
+        .unwrap_or_default();
 
     let mut updated_rows = Vec::new();
 
@@ -217,11 +229,15 @@ pub async fn complete_request(
     }
 
     hub.spreadsheets()
-        .values_update(ValueRange {
-            range: Some(request_range.to_string()),
-            values: Some(updated_rows),
-            ..Default::default()
-        }, &request_sheet_id, request_range)
+        .values_update(
+            ValueRange {
+                range: Some(request_range.to_string()),
+                values: Some(updated_rows),
+                ..Default::default()
+            },
+            &request_sheet_id,
+            request_range,
+        )
         .value_input_option("RAW")
         .doit()
         .await?;
@@ -233,10 +249,13 @@ pub async fn complete_request(
             product_name,
         ))
         .color(0x00ff00);
-    
-    thread_id.send_message(&ctx.http, CreateMessage::new().embed(embed)).await?;
-    // comp.channel_id
-    // .send_message(&ctx.http, poise::serenity_prelude::CreateMessage::new().embed(embed))
-    // .await?;
+
+    thread_id
+        .send_message(&ctx.http, CreateMessage::new().embed(embed))
+        .await?;
+
+    thread_id
+        .edit_thread(&ctx.http, EditThread::default().locked(true))
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
Update:

/request update (button)

    Takes the unique request ID embedded in the button
    Queries Google Sheets for all rows matching that ID
    Pulls resource names & requested amounts from those rows
    Compares each request amount against the live inventory
    Presents a "✅ In-Stock" vs. "🛠 Remaining" summary back to the user
    Displays "All materials collected! 🎉" once everything is in stock

/request complete (button)

    Verifies that no materials remain outstanding
    Marks the request as complete in the Discord thread (flair + "Complete!" text)
    Updates the request’s rows in Google Sheets from in_progress → complete
    Locks & archives the thread so no further replies can be sent

/submit

    Restricts the resource drop down to only valid, predetermined options

/request finish

    Posts the initial request into the public channel without subtracting inventory
    Embeds only the raw materials list (inventory subtraction happens later in "complete")

Miscellaneous

    ✓ Validated that the parsed resource list matches the inventory names
    ✓ Implemented “water → corpse” conversion at a rate of 45,000 water per corpse
    ✓ Cleaned up both the inventory and test Google Sheets in preparation for release
    ✓ Added a comprehensive .env.example for Usage section in the final README

Testing Notes

- [ ] Multiple requests can run in parallel without state collision
- [ ] Submit / Update / Complete all play nicely together under heavy load
- [ ] Verified thread locking prevents further replies once complete

Next Steps / Future Ideas

    /request bulk_add: reject invalid text, unrecognized resource names, and nonsensical counts
    /request cancel: allow users to remove an in‑progress request from the sheet and Discord
    Greyed‑out "Complete" button: enable only after a successful "Update" check
    Edit original message on complete: transform "🔷 CRAFTING REQUEST" embed into "✅ Completed Request"
    Readme with .env.example, Usage, etc.